### PR TITLE
init.fc: Added fcontext for openrc-{init,shutdown}.

### DIFF
--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -100,6 +100,7 @@ ifdef(`distro_gentoo',`
 #
 /usr/sbin/openrc		--	gen_context(system_u:object_r:rc_exec_t,s0)
 /usr/sbin/openrc-init		--	gen_context(system_u:object_r:init_exec_t,s0)
+/usr/sbin/openrc-shutdown	--	gen_context(system_u:object_r:init_exec_t,s0)
 
 #
 # /var

--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -99,6 +99,7 @@ ifdef(`distro_gentoo',`
 # /sbin
 #
 /usr/sbin/openrc		--	gen_context(system_u:object_r:rc_exec_t,s0)
+/usr/sbin/openrc-init		--	gen_context(system_u:object_r:init_exec_t,s0)
 
 #
 # /var


### PR DESCRIPTION
Handle booting with `init=/sbin/openrc-init`.