### PR TITLE
portage: gcc-config fixes

### DIFF
--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -132,6 +132,7 @@ libs_run_ldconfig(gcc_config_t, portage_roles)
 libs_manage_shared_libs(gcc_config_t)
 # gcc-config creates a temp dir for the libs
 libs_manage_lib_dirs(gcc_config_t)
+libs_manage_lib_symlinks(gcc_config_t)
 
 logging_send_syslog_msg(gcc_config_t)
 

--- a/policy/modules/admin/portage.te
+++ b/policy/modules/admin/portage.te
@@ -111,6 +111,7 @@ kernel_read_kernel_sysctls(gcc_config_t)
 corecmd_exec_shell(gcc_config_t)
 corecmd_exec_bin(gcc_config_t)
 corecmd_manage_bin_files(gcc_config_t)
+corecmd_manage_bin_symlinks(gcc_config_t)
 
 domain_use_interactive_fds(gcc_config_t)
 

--- a/policy/modules/kernel/corecommands.if
+++ b/policy/modules/kernel/corecommands.if
@@ -335,6 +335,25 @@ interface(`corecmd_manage_bin_files',`
 
 ########################################
 ## <summary>
+##	Manage symlinks for bin files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`corecmd_manage_bin_symlinks',`
+	gen_require(`
+		type bin_t;
+	')
+
+	corecmd_search_bin($1)
+	manage_lnk_files_pattern($1, bin_t, bin_t)
+')
+
+########################################
+## <summary>
 ##	Relabel to and from the bin type.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/libraries.if
+++ b/policy/modules/system/libraries.if
@@ -391,6 +391,24 @@ interface(`libs_delete_lib_symlinks',`
 
 ########################################
 ## <summary>
+##	Manage generic symlinks in library directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`libs_manage_lib_symlinks',`
+	gen_require(`
+		type lib_t;
+	')
+
+	manage_lnk_files_pattern($1, lib_t, lib_t)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete shared libraries.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
`gcc-config` needs access to `/` (it checks that it can write to `EROOT`) and also needs access to symlinks in `bin_t` and `lib_t` to install new compiler versions.