### PR TITLE
iptables.te: Added init_read_script_pipes().

### DIFF
--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -85,6 +85,7 @@ auth_use_nsswitch(iptables_t)
 
 init_use_fds(iptables_t)
 init_use_script_ptys(iptables_t)
+init_read_script_pipes(iptables_t)
 # to allow rules to be saved on reboot:
 init_rw_script_pipes(iptables_t)
 init_rw_script_tmp_files(iptables_t)


### PR DESCRIPTION
I needed this in my policies after I set in `/etc/conf.d/nftables`: `SAVE_ON_STOP="no"`.