### PR TITLE
netutils: Added policy for ss to access netlink

### DIFF
--- a/policy/modules/admin/netutils.fc
+++ b/policy/modules/admin/netutils.fc
@@ -17,5 +17,6 @@
 /usr/sbin/hping2	--	gen_context(system_u:object_r:ping_exec_t,s0)
 /usr/sbin/iptstate	--	gen_context(system_u:object_r:netutils_exec_t,s0)
 /usr/sbin/send_arp	--	gen_context(system_u:object_r:ping_exec_t,s0)
+/usr/sbin/ss		--	gen_context(system_u:object_r:ss_exec_t,s0)
 /usr/sbin/tcpdump	--	gen_context(system_u:object_r:netutils_exec_t,s0)
 /usr/sbin/traceroute.*	--	gen_context(system_u:object_r:traceroute_exec_t,s0)

--- a/policy/modules/admin/netutils.if
+++ b/policy/modules/admin/netutils.if
@@ -214,6 +214,50 @@ interface(`netutils_exec_ping',`
 
 ########################################
 ## <summary>
+##      Execute a domain transition to run ss.
+## </summary>
+## <param name="domain">
+## <summary>
+##      Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`netutils_domtrans_ss',`
+        gen_require(`
+		type ss_t, ss_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        domtrans_pattern($1, ss_exec_t, ss_t)
+')
+
+########################################
+## <summary>
+##      Execute ss in the ss domain, and
+##      allow the specified role the ss domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed to transition.
+##      </summary>
+## </param>
+## <param name="role">
+##      <summary>
+##      Role allowed access.
+##      </summary>
+## </param>
+#
+interface(`netutils_run_ss',`
+        gen_require(`
+		type ss_t;
+        ')
+
+        netutils_domtrans_ss($1)
+        role $2 types ss_t;
+')
+
+########################################
+## <summary>
 ##	Execute traceroute in the traceroute domain.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/admin/netutils.te
+++ b/policy/modules/admin/netutils.te
@@ -23,6 +23,9 @@ type ping_t;
 type ping_exec_t;
 init_system_domain(ping_t, ping_exec_t)
 
+type ss_t;
+type ss_exec_t;
+
 type traceroute_t;
 type traceroute_exec_t;
 init_system_domain(traceroute_t, traceroute_exec_t)
@@ -147,6 +150,23 @@ ifdef(`hide_broken_symptoms',`
 optional_policy(`
 	munin_append_log(ping_t)
 ')
+
+########################################
+#
+# ss local policy
+#
+
+domain_use_interactive_fds(ss_t)
+files_read_etc_files(ss_t)
+kernel_read_net_sysctls(ss_t)
+kernel_read_network_state(ss_t)
+kernel_read_proc_symlinks(ss_t)
+kernel_read_system_state(ss_t)
+userdom_use_inherited_user_terminals(ss_t)
+userdom_user_application_domain(ss_t, ss_exec_t)
+
+allow ss_t self:capability net_admin;
+allow ss_t self:netlink_tcpdiag_socket r_netlink_socket_perms;
 
 ########################################
 #

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1523,6 +1523,10 @@ interface(`userdom_security_admin_template',`
 	')
 
 	optional_policy(`
+		netutils_run_ss($1, $2)
+	')
+
+	optional_policy(`
 		samhain_run($1, $2)
 	')
 


### PR DESCRIPTION
Gentoo is stricter than other distros with SELinux policy, so `ss` on it doesn't display any of the normal connection information shown.

This policy change makes commands like `ss --tcp -i` useful again, however the modules required need to still be manually loaded:

```
type=AVC msg=audit(1630882680.457:5146): avc:  denied  { module_request } for  pid=32169 comm="ss" kmod="net-pf-16-proto-4-type-2" scontext=staff_u:sysadm_r:ss_t tcontext=system_u:system_r:kernel_t tclass=system permissive=0
```