### PR TITLE
selinuxutil.te: Allow run_init_t to access SELinux status page

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -437,6 +437,7 @@ selinux_compute_access_vector(run_init_t)
 selinux_compute_create_context(run_init_t)
 selinux_compute_relabel_context(run_init_t)
 selinux_compute_user_contexts(run_init_t)
+selinux_use_status_page(run_init_t)
 
 auth_use_nsswitch(run_init_t)
 auth_run_chk_passwd(run_init_t, run_init_roles)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/822642

AVC logged:

```
type=AVC msg=audit(1636973254.665:22855): avc:  denied  { map } for  pid=26956 comm="run_init" path="/sys/fs/selinux/status" dev="selinuxfs" ino=19 scontext=staff_u:sysadm_r:run_init_t tcontext=system_u:object_r:
security_t tclass=file permissive=0
type=USER_AVC msg=audit(1636973254.665:22856): pid=26956 uid=0 auid=1000 ses=32 subj=staff_u:sysadm_r:run_init_t msg='avc: could not open selinux status page: 13 (Permission denied)  exe="/usr/sbin/run_init" sauid=0 hostname=? addr=? terminal=pts/0'
```